### PR TITLE
Start isolating issue...

### DIFF
--- a/src/bin/err_async.rs
+++ b/src/bin/err_async.rs
@@ -15,8 +15,8 @@ impl Worker {
         }
     }
 
-    async fn send(&mut self, msg: &[u8]) -> io::Result<()> {
-        self.with(|stream| {
+    async fn send<'a>(&'a mut self, msg: &[u8]) -> io::Result<()> {
+        self.with(|stream: &'a mut TcpStream| {
             use tokio::io::AsyncWriteExt;
 
             stream.write_all(msg)
@@ -24,9 +24,9 @@ impl Worker {
         .await
     }
 
-    async fn with<Fun, Fut, T>(&mut self, f: Fun) -> io::Result<T>
+    async fn with<'a, Fun, Fut, T>(&'a mut self, f: Fun) -> io::Result<T>
     where
-        Fun: FnOnce(&mut TcpStream) -> Fut,
+        Fun: FnOnce(&'a mut TcpStream) -> Fut,
         Fut: Future<Output = io::Result<T>>,
     {
         if self.stream.is_none() {


### PR DESCRIPTION
Still doesn't compile, but I think this helps show where the issue is a bit more clearly.

```
error[E0506]: cannot assign to `self.stream` because it is borrowed
  --> src/bin/err_async.rs:41:13
   |
27 |     async fn with<'a, Fun, Fut, T>(&'a mut self, f: Fun) -> io::Result<T>
   |                   -- lifetime `'a` defined here
...
37 |             let stream = self.stream.as_mut().unwrap();
   |                          ----------- `self.stream` is borrowed here
38 |             f(stream).await
   |             --------- argument requires that `self.stream` is borrowed for `'a`
...
41 |             self.stream = None;
   |             ^^^^^^^^^^^ `self.stream` is assigned to here but it was already borrowed
```